### PR TITLE
Fix race when initializing ringBufferRateLimiter

### DIFF
--- a/distributed_test.go
+++ b/distributed_test.go
@@ -96,8 +96,7 @@ func TestDistributed(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to parse duration")
 			}
-			var simulatedPeer ringBufferRateLimiter
-			simulatedPeer.initialize(maxEvents, parsedDuration)
+			simulatedPeer := NewRingBufferRateLimiter(maxEvents, parsedDuration)
 
 			for i := 0; i < testCase.peerRequests; i++ {
 				if when := simulatedPeer.When(); when != 0 {
@@ -106,7 +105,7 @@ func TestDistributed(t *testing.T) {
 			}
 
 			zoneLimiters := new(sync.Map)
-			zoneLimiters.Store("static", &simulatedPeer)
+			zoneLimiters.Store("static", simulatedPeer)
 
 			rlState := rlState{
 				Timestamp: testCase.peerStateTimeStamp,
@@ -133,6 +132,13 @@ func TestDistributed(t *testing.T) {
 	"storage": {
 		"module": "file_system",
 		"root": "%s"
+	},
+	"logging": {
+		"logs": {
+			"default": {
+				"level": "DEBUG"
+			}
+		}
 	},
 	"apps": {
 		"http": {

--- a/distributed_test.go
+++ b/distributed_test.go
@@ -109,7 +109,7 @@ func TestDistributed(t *testing.T) {
 			rlState := rlState{
 				Timestamp: testCase.peerStateTimeStamp,
 				Zones: map[string]map[string]rlStateValue{
-					zone: rlStateForZone(zoneLimiters, now()),
+					zone: zoneLimiters.rlStateForZone(now()),
 				},
 			}
 

--- a/distributed_test.go
+++ b/distributed_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -96,7 +95,7 @@ func TestDistributed(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to parse duration")
 			}
-			simulatedPeer := NewRingBufferRateLimiter(maxEvents, parsedDuration)
+			simulatedPeer := newRingBufferRateLimiter(maxEvents, parsedDuration)
 
 			for i := 0; i < testCase.peerRequests; i++ {
 				if when := simulatedPeer.When(); when != 0 {
@@ -104,8 +103,8 @@ func TestDistributed(t *testing.T) {
 				}
 			}
 
-			zoneLimiters := new(sync.Map)
-			zoneLimiters.Store("static", simulatedPeer)
+			zoneLimiters := newRateLimiterMap()
+			zoneLimiters.limiters["static"] = simulatedPeer
 
 			rlState := rlState{
 				Timestamp: testCase.peerStateTimeStamp,

--- a/handler.go
+++ b/handler.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -165,30 +164,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhtt
 
 		// make key for the individual rate limiter in this zone
 		key := repl.ReplaceAll(rl.Key, "")
-
-		var limiter *ringBufferRateLimiter
-		loadedLimiter, ok := rl.limiters.Load(key)
-		if ok {
-			limiter = loadedLimiter.(*ringBufferRateLimiter)
-		} else {
-			var newLimiter *ringBufferRateLimiter
-			poolLimiter := ringBufPool.Get()
-			if poolLimiter == nil {
-				// Nothing is in the pool, create a new limiter.
-				newLimiter = NewRingBufferRateLimiter(rl.MaxEvents, time.Duration(rl.Window))
-			} else {
-				newLimiter = poolLimiter.(*ringBufferRateLimiter)
-			}
-
-			loadedLimiter, loaded := rl.limiters.LoadOrStore(key, newLimiter)
-			if loaded {
-				// We didn't end up needing the pool's limiter, since a concurrent request
-				// has loaded its own limiter. Store it for later use.
-				ringBufPool.Put(newLimiter)
-			}
-
-			limiter = loadedLimiter.(*ringBufferRateLimiter)
-		}
+		limiter := rl.limitersMap.getOrInsert(key, rl.MaxEvents, time.Duration(rl.Window))
 
 		if h.Distributed == nil {
 			// internal rate limiter only
@@ -245,42 +221,8 @@ func (h Handler) sweepRateLimiters(ctx context.Context) {
 	for {
 		select {
 		case <-cleanerTicker.C:
-			// iterate all rate limit zones
 			rateLimits.Range(func(key, value interface{}) bool {
-				rlMap := value.(*sync.Map)
-
-				// iterate all static and dynamic rate limiters within zone
-				rlMap.Range(func(key, value interface{}) bool {
-					if value == nil {
-						return true
-					}
-					rl := value.(*ringBufferRateLimiter)
-
-					rl.mu.Lock()
-					// no point in keeping a ring buffer of size 0 around
-					if len(rl.ring) == 0 {
-						rl.mu.Unlock()
-						rlMap.Delete(key)
-						return true
-					}
-					// get newest event in ring (should come right before oldest)
-					cursorNewest := rl.cursor - 1
-					if cursorNewest < 0 {
-						cursorNewest = len(rl.ring) - 1
-					}
-					newest := rl.ring[cursorNewest]
-					window := rl.window
-					rl.mu.Unlock()
-
-					// if newest event in memory is outside the window,
-					// the entire ring has expired and can be forgotten
-					if newest.Add(window).Before(now()) {
-						rlMap.Delete(key)
-					}
-
-					return true
-				})
-
+				value.(*rateLimitersMap).sweep()
 				return true
 			})
 
@@ -292,13 +234,6 @@ func (h Handler) sweepRateLimiters(ctx context.Context) {
 
 // rateLimits persists RL zones through config changes.
 var rateLimits = caddy.NewUsagePool()
-
-// ringBufPool reduces allocations from unneeded rate limiters.
-var ringBufPool = sync.Pool{
-	// New: func() interface{} {
-	// 	return new(ringBufferRateLimiter)
-	// },
-}
 
 // Interface guards
 var (

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -46,7 +46,7 @@ type RateLimit struct {
 
 	zoneName string
 
-	limiters *sync.Map
+	limitersMap *rateLimitersMap
 }
 
 func (rl *RateLimit) provision(ctx caddy.Context, name string) error {
@@ -69,22 +69,81 @@ func (rl *RateLimit) provision(ctx caddy.Context, name string) error {
 	}
 
 	// ensure rate limiter state endures across config changes
-	rl.limiters = new(sync.Map)
-	if val, loaded := rateLimits.LoadOrStore(name, rl.limiters); loaded {
-		rl.limiters = val.(*sync.Map)
+	rl.limitersMap = newRateLimiterMap()
+	if val, loaded := rateLimits.LoadOrStore(name, rl.limitersMap); loaded {
+		rl.limitersMap = val.(*rateLimitersMap)
 	}
-
-	// update existing rate limiters with new settings
-	rl.limiters.Range(func(key, value interface{}) bool {
-		limiter := value.(*ringBufferRateLimiter)
-		limiter.SetMaxEvents(rl.MaxEvents)
-		limiter.SetWindow(time.Duration(rl.Window))
-		return true
-	})
+	rl.limitersMap.updateAll(rl.MaxEvents, time.Duration(rl.Window))
 
 	return nil
 }
 
 func (rl *RateLimit) permissiveness() float64 {
 	return float64(rl.MaxEvents) / float64(rl.Window)
+}
+
+type rateLimitersMap struct {
+	limiters map[string]*ringBufferRateLimiter
+	mu       sync.Mutex
+}
+
+func newRateLimiterMap() *rateLimitersMap {
+	var rlm rateLimitersMap
+	rlm.limiters = make(map[string]*ringBufferRateLimiter)
+	return &rlm
+}
+
+// getOrInsert returns an existing rate limiter from the map, or inserts a new
+// one with the desired settings and returns it.
+func (rlm *rateLimitersMap) getOrInsert(key string, maxEvents int, window time.Duration) *ringBufferRateLimiter {
+	rlm.mu.Lock()
+	defer rlm.mu.Unlock()
+	rateLimiter, ok := rlm.limiters[key]
+	if !ok {
+		newRateLimiter := newRingBufferRateLimiter(maxEvents, window)
+		rlm.limiters[key] = newRateLimiter
+		return newRateLimiter
+	}
+	return rateLimiter
+}
+
+// updateAll updates existing rate limiters with new settings.
+func (rlm *rateLimitersMap) updateAll(maxEvents int, window time.Duration) {
+	rlm.mu.Lock()
+	defer rlm.mu.Unlock()
+
+	for _, limiter := range rlm.limiters {
+		limiter.SetMaxEvents(maxEvents)
+		limiter.SetWindow(time.Duration(window))
+	}
+}
+
+// sweep cleans up expired rate limit states.
+func (rlm *rateLimitersMap) sweep() {
+	rlm.mu.Lock()
+	defer rlm.mu.Unlock()
+
+	for key, rl := range rlm.limiters {
+		rl.mu.Lock()
+		// no point in keeping a ring buffer of size 0 around
+		if len(rl.ring) == 0 {
+			rl.mu.Unlock()
+			delete(rlm.limiters, key)
+			continue
+		}
+		// get newest event in ring (should come right before oldest)
+		cursorNewest := rl.cursor - 1
+		if cursorNewest < 0 {
+			cursorNewest = len(rl.ring) - 1
+		}
+		newest := rl.ring[cursorNewest]
+		window := rl.window
+		rl.mu.Unlock()
+
+		// if newest event in memory is outside the window,
+		// the entire ring has expired and can be forgotten
+		if newest.Add(window).Before(now()) {
+			delete(rlm.limiters, key)
+		}
+	}
 }

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -30,11 +30,11 @@ type ringBufferRateLimiter struct {
 	cursor int         // always points to the oldest timestamp
 }
 
-// NewRingBufferRateLimiter sets up a new rate limiter, allowing maxEvents
+// newRingBufferRateLimiter sets up a new rate limiter, allowing maxEvents
 // in a sliding window of size window. If maxEvents is 0, no events are
 // allowed. If window is 0, all events are allowed. It panics if maxEvents or
 // window are less than zero.
-func NewRingBufferRateLimiter(maxEvents int, window time.Duration) *ringBufferRateLimiter {
+func newRingBufferRateLimiter(maxEvents int, window time.Duration) *ringBufferRateLimiter {
 	r := new(ringBufferRateLimiter)
 	if maxEvents < 0 {
 		panic("maxEvents cannot be less than zero")

--- a/ringbuffer.go
+++ b/ringbuffer.go
@@ -30,16 +30,12 @@ type ringBufferRateLimiter struct {
 	cursor int         // always points to the oldest timestamp
 }
 
-// initialize sets up the rate limiter if it isn't already, allowing maxEvents
+// NewRingBufferRateLimiter sets up a new rate limiter, allowing maxEvents
 // in a sliding window of size window. If maxEvents is 0, no events are
 // allowed. If window is 0, all events are allowed. It panics if maxEvents or
-// window are less than zero. This method is idempotent.
-func (r *ringBufferRateLimiter) initialize(maxEvents int, window time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.window != 0 || r.ring != nil {
-		return
-	}
+// window are less than zero.
+func NewRingBufferRateLimiter(maxEvents int, window time.Duration) *ringBufferRateLimiter {
+	r := new(ringBufferRateLimiter)
 	if maxEvents < 0 {
 		panic("maxEvents cannot be less than zero")
 	}
@@ -48,6 +44,7 @@ func (r *ringBufferRateLimiter) initialize(maxEvents int, window time.Duration) 
 	}
 	r.window = window
 	r.ring = make([]time.Time, maxEvents) // TODO: we can probably pool these
+	return r
 }
 
 // When returns the duration before the next allowable event; it does not block.

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -23,9 +23,8 @@ func TestCount(t *testing.T) {
 	initTime()
 
 	var zeroTime time.Time
-	var rb ringBufferRateLimiter
 	bufSize := 10
-	rb.initialize(bufSize, time.Duration(bufSize)*time.Second)
+	rb := NewRingBufferRateLimiter(bufSize, time.Duration(bufSize)*time.Second)
 	startTime := now()
 
 	count, oldest := rb.Count(now())

--- a/ringbuffer_test.go
+++ b/ringbuffer_test.go
@@ -24,7 +24,7 @@ func TestCount(t *testing.T) {
 
 	var zeroTime time.Time
 	bufSize := 10
-	rb := NewRingBufferRateLimiter(bufSize, time.Duration(bufSize)*time.Second)
+	rb := newRingBufferRateLimiter(bufSize, time.Duration(bufSize)*time.Second)
 	startTime := now()
 
 	count, oldest := rb.Count(now())


### PR DESCRIPTION
Supports https://github.com/mholt/caddy-ratelimit/issues/36 and https://github.com/divviup/janus-ops/issues/1336.

Fixes a race condition between `ringBufferRateLimiter` creation and its insertion into a map. Do this by locking the entire map when we get or insert a `ringBufferRateLimiter`.

I have replaced use of `sync.Map` with a normal `map[string]*ringBufferRateLimiter` and a `sync.Mutex`. They are passed around with a `rateLimitersMap` struct. I've factored out logic into methods of `rateLimitersMap`, which enables some careful use of `defer rlm.mu.Unlock()` to avoid leaving a lock held open on `panic()`.

We didn't see any need for a `sync.Map`. The docs suggest against using it for type safety, and none of the suggested use cases apply. https://pkg.go.dev/sync#Map 

I've removed the `sync.Pool`, for now. Since `ringBufferRateLimiter` creation and insertion is fully synchronized, I don't see a need for it.
